### PR TITLE
Fix `identify` -> `identity` typo.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
     'prefer-constant': require('./rules/prefer-constant'),
     'prefer-flat-map': require('./rules/prefer-flat-map'),
     'prefer-get': require('./rules/prefer-get'),
-    'prefer-identify': require('./rules/prefer-identify'),
+    'prefer-identity': require('./rules/prefer-identity'),
     'use-fp': require('./rules/use-fp')
   },
   configs: {


### PR DESCRIPTION
This otherwise causes the plugin not to be able to load.

Might want to consider some kind of testing that ensures your plugin is, by default, loadable. 😄 