### PR TITLE
Fix false positives from consistent-compose

### DIFF
--- a/rules/consistent-compose.js
+++ b/rules/consistent-compose.js
@@ -1,6 +1,10 @@
 'use strict';
 
+var _ = require('lodash/fp');
 var enhance = require('./core/enhance');
+
+var knownComposeMethods = ['flow', 'flowRight', 'compose', 'pipe'];
+var isKnownComposeMethod = _.includes(_, knownComposeMethods);
 
 module.exports = function (context) {
   var info = enhance();
@@ -12,7 +16,7 @@ module.exports = function (context) {
   return info.merge({
     CallExpression: function (node) {
       var name = info.helpers.isMethodCall(node);
-      if (name !== false && name !== composeMethod) {
+      if (isKnownComposeMethod(name) && name !== composeMethod) {
         context.report(node, 'Forbidden use of `' + name + '`. Use `' + composeMethod + '` instead');
       }
     }
@@ -21,5 +25,5 @@ module.exports = function (context) {
 
 module.exports.schema = [{
   type: 'string',
-  enum: ['flow', 'flowRight', 'compose', 'pipe']
+  enum: knownComposeMethods
 }];

--- a/test/consistent-compose.js
+++ b/test/consistent-compose.js
@@ -43,6 +43,46 @@ test(() => {
       {
         code: code(`compose(fn1, fn2)(x);`, false),
         options: ['flow']
+      },
+      // Check assignments created via composition
+      {
+        code: code(`var composed = flow(fn1, fn2); var b = composed(x);`, ['flow']),
+        options: ['flow']
+      },
+      {
+        code: code(`var composed = _.pipe(fn1, fn2); var b = composed(x);`),
+        options: ['pipe']
+      },
+      // Make sure there are no false positives on non-compose functions
+      {
+        code: code(`_.partial(fn1, args)(x);`),
+        options: ['flow']
+      },
+      {
+        code: code(`partial(fn1, args)(x);`, ['partial']),
+        options: ['flow']
+      },
+      {
+        code: code(`_.map(fn1, iterable);`),
+        options: ['flow']
+      },
+      {
+        code: code(`map(fn1, iterable);`, ['map']),
+        options: ['flow']
+      },
+      {
+        code: code(`var fn = map(fn2);`, ['map']),
+        options: ['flow']
+      },
+      {
+        code: code(`var fn = _.map(fn2);`),
+        options: ['flow']
+      },
+      // Should not warn on ambiguously renamed imports
+      // This should probably be restrictable by a seperate rule
+      {
+        code: code(`import {map as flow} from 'lodash/fp'; flow(fn1, iterable);`, false),
+        options: ['compose']
       }
     ],
     invalid: [
@@ -104,6 +144,15 @@ test(() => {
       },
       {
         code: code(`var {c: compose} = require('lodash/fp'); c(fn1, fn2)(x);`, false),
+        options: ['flow'],
+        errors: [{
+          ...error, message: 'Forbidden use of `compose`. Use `flow` instead'
+        }]
+      },
+      // Should still warn on ambiguously renamed imports
+      // This should probably be restrictable by a seperate rule
+      {
+        code: code(`import {compose as flow} from 'lodash/fp'; flow(fn1, fn2)(x);`, false),
         options: ['flow'],
         errors: [{
           ...error, message: 'Forbidden use of `compose`. Use `flow` instead'


### PR DESCRIPTION
Turning on consistent-compose returned a lint error when any lodash method was used that did not match the method specified in the rule's options.

For example, given config:
```yaml
extends: ['plugin:lodash-fp/recommended']
plugins: [lodash-fp]
rules:
  lodash-fp/consistent-compose: [error, flow]
```
And usage:
```javascript
import { curry, find, flow, get, head, map } from 'lodash/fp';

...

const findSegment = name => find({ name }, animSegments);
```

eslint would return ```'Forbidden use of `find`. Use `flow` instead'```

