### PR TITLE
Determine composition method call in lodash-util, improve coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+coverage
 .nyc_output

--- a/rules/consistent-compose.js
+++ b/rules/consistent-compose.js
@@ -1,10 +1,7 @@
 'use strict';
 
-var _ = require('lodash/fp');
 var enhance = require('./core/enhance');
-
-var knownComposeMethods = ['flow', 'flowRight', 'compose', 'pipe'];
-var isKnownComposeMethod = _.includes(_, knownComposeMethods);
+var constants = require('./core/constants');
 
 module.exports = function (context) {
   var info = enhance();
@@ -15,8 +12,8 @@ module.exports = function (context) {
 
   return info.merge({
     CallExpression: function (node) {
-      var method = info.helpers.isMethodCall(node);
-      if (method && isKnownComposeMethod(method.name) && method.name !== composeMethod) {
+      var method = info.helpers.isComposeMethod(node);
+      if (method && method.name !== composeMethod) {
         context.report(node, 'Forbidden use of `' + method.name + '`. Use `' + composeMethod + '` instead');
       }
     }
@@ -25,5 +22,5 @@ module.exports = function (context) {
 
 module.exports.schema = [{
   type: 'string',
-  enum: knownComposeMethods
+  enum: constants.COMPOSITION_METHODS
 }];

--- a/rules/core/constants.js
+++ b/rules/core/constants.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var COMPOSITION_METHODS = ['flow', 'flowRight', 'pipe', 'compose'];
+
+module.exports = {
+  COMPOSITION_METHODS: COMPOSITION_METHODS
+};

--- a/rules/core/constants.js
+++ b/rules/core/constants.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var COMPOSITION_METHODS = ['flow', 'flowRight', 'pipe', 'compose'];
+var COMPOSITION_METHODS = ['compose', 'flow', 'flowRight', 'pipe'];
 
 module.exports = {
   COMPOSITION_METHODS: COMPOSITION_METHODS

--- a/rules/core/lodash-util.js
+++ b/rules/core/lodash-util.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash/fp');
 var data = require('./lodash-data');
+var constants = require('./constants');
 
 module.exports = function (imports) {
   var isIdentifier = _.matches({type: 'Identifier'});
@@ -104,8 +105,6 @@ module.exports = function (imports) {
       buildInfo(node, node.property.name, node.property.name);
   });
 
-  var compositionMethods = ['compose', 'flow', 'flowRight', 'pipe'];
-
   var getComposeMethodArgMethods = _.curry(function _getComposeMethodArgMethods(name, node) {
     var methodNames = node.arguments.map(function (arg) {
       return isMethodCall(arg) || isMember(arg);
@@ -132,7 +131,7 @@ module.exports = function (imports) {
     isMethodOf: isMethodOf,
     isAnyMethodOf: isAnyMethodOf,
 
-    isComposeMethod: isMethodCallOf(compositionMethods),
+    isComposeMethod: isMethodCallOf(constants.COMPOSITION_METHODS),
     getComposeMethodArgMethods: getComposeMethodArgMethods
   };
 };

--- a/rules/no-single-composition.js
+++ b/rules/no-single-composition.js
@@ -2,19 +2,15 @@
 
 var enhance = require('./core/enhance');
 
-var composeMethods = ['compose', 'flow', 'flowRight', 'pipe'];
-
 module.exports = function (context) {
   var info = enhance();
-
-  var match = info.helpers.isMethodCallOf(composeMethods);
 
   return info.merge({
     CallExpression: function (node) {
       if (node.arguments.length > 1) {
         return;
       }
-      var method = match(node);
+      var method = info.helpers.isComposeMethod(node);
       if (method) {
         context.report(node, '`' + method.name + '` should have at least two arguments');
       }

--- a/test/consistent-compose.js
+++ b/test/consistent-compose.js
@@ -82,6 +82,15 @@ test(() => {
       {
         code: code(`import {map as flow} from 'lodash/fp'; flow(fn1, iterable);`, false),
         options: ['compose']
+      },
+      // Should not warn if no compose function name specified
+      {
+        code: code(`compose(fn1, fn2); pipe(fn1, fn2);`, ['compose', 'pipe']),
+        options: []
+      },
+      {
+        code: code(`_.compose(fn1, fn2); _.pipe(fn1, fn2);`),
+        options: []
       }
     ],
     invalid: [


### PR DESCRIPTION
Noticed that `nyc` was added to the project, so I gave it a spin and noticed consistent-compose coverage was not up to par, so I've added more tests to fix that.

Also noticed composition method name checks were happening independently in a couple of rules and that there was an exisiting, underused isCompositionMethod in lodash-util. Changed checks across rules to use the util method instead.

The main thing I'm iffy about is the new core/constants.js file. Is that suitably named? Do we want a freely importable constants file? It's mainly there to enable [this enumerable export](https://github.com/jfmengels/eslint-plugin-lodash-fp/commit/e875f0a365fc0aa23165d1c0cfa2d3e78c9edf75#diff-0092f0ec9207f63457be5cb484ab8710L28), since it happens outside the context of the lodash-util(import) return.

Let me know your thoughts.