### PR TITLE
Adds bindAll to methods excluded from no-unused-result

### DIFF
--- a/rules/core/constants.js
+++ b/rules/core/constants.js
@@ -2,8 +2,10 @@
 
 const COMPOSITION_METHODS = ['compose', 'flow', 'flowRight', 'pipe'];
 const FOREACH_METHODS = ['forEach', 'forEachRight', 'each', 'eachRight', 'forIn', 'forInRight', 'forOwn', 'forOwnRight'];
+const SIDE_EFFECT_METHODS = FOREACH_METHODS.concat(['bindAll']);
 
 module.exports = {
   COMPOSITION_METHODS,
-  FOREACH_METHODS
+  FOREACH_METHODS,
+  SIDE_EFFECT_METHODS
 };

--- a/rules/no-unused-result.js
+++ b/rules/no-unused-result.js
@@ -6,7 +6,7 @@ const constants = require('./core/constants');
 
 const isForEach = _.flow(
   _.get('realName'),
-  _.includes(_, constants.FOREACH_METHODS)
+  _.includes(_, constants.SIDE_EFFECT_METHODS)
 );
 
 function isMethodCall(info, node) {


### PR DESCRIPTION
Resolves https://github.com/jfmengels/eslint-plugin-lodash-fp/issues/35

* Adds a new constant for methods that cause side effects
* Uses side effect methods constant instead of for each constant in no-unused-result