### PR TITLE
ignore Object.prototype methods when checking for Lodash imports

### DIFF
--- a/rules/core/enhance.js
+++ b/rules/core/enhance.js
@@ -21,7 +21,7 @@ function strippedModuleName(strippedName, name) {
 }
 
 module.exports = function () {
-  const imports = {};
+  const imports = Object.create(null);
 
   // `ImportDeclaration` and `VariableDeclarator` will find Lodash imports and require()
   // and fill `imports` with what is found


### PR DESCRIPTION
Fixes #51 

Same issue as in https://github.com/wix/eslint-plugin-lodash/issues/115