### PR TITLE
Exempt defer and delay from unused-expression

### DIFF
--- a/rules/core/constants.js
+++ b/rules/core/constants.js
@@ -2,7 +2,7 @@
 
 const COMPOSITION_METHODS = ['compose', 'flow', 'flowRight', 'pipe'];
 const FOREACH_METHODS = ['forEach', 'forEachRight', 'each', 'eachRight', 'forIn', 'forInRight', 'forOwn', 'forOwnRight'];
-const SIDE_EFFECT_METHODS = FOREACH_METHODS.concat(['bindAll']);
+const SIDE_EFFECT_METHODS = FOREACH_METHODS.concat(['bindAll', 'defer', 'delay']);
 
 module.exports = {
   COMPOSITION_METHODS,


### PR DESCRIPTION
`defer` and `delay` is basically `setTimeout` with the delay argument omitted (to work like [setImmediate](https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate)) or with the arguments reversed (which is way easier to read imo).

They are side effect methods, and useful without the result, which is only needed if you plan to cancel them. However the `unused-expression` rule doesn't allow this:

```js
_.defer(() => {
    console.log("You waited a tick");
});

_.delay(1000, () => {
    console.log("You waited a second");
});
```

With this PR, they would be exempted from the `unused-expression` rule