### PR TITLE
Revert Ava to 0.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "req-all": "^1.0.0"
   },
   "devDependencies": {
-    "ava": "^0.25.0",
+    "ava": "^0.17.0",
     "eslint": "^4.17.0",
     "eslint-ava-rule-tester": "^2.0.0",
     "inject-in-tag": "^1.1.1",


### PR DESCRIPTION
Ava 0.18 seems to have broken Object rest/spread for Node 8.2 or older, by some babel conf change.

Ava 1 is coming soon, but isn't backwards compatible.

This fixed the test command for me locally for older Node.js versions.