### PR TITLE
[test] Adding a test case for failing method name import

### DIFF
--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -13,5 +13,9 @@ module.exports = {
       return `import {${header.join(', ')}} from 'lodash/fp';${content}`;
     }
     return importHeader(header || '_') + content;
+  },
+
+  toString(value) {
+    return `${value}`;
   }
 };

--- a/test/object-prototype-methods.js
+++ b/test/object-prototype-methods.js
@@ -1,0 +1,30 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/no-for-each';
+import {code} from './helpers';
+
+const ruleTester = avaRuleTester(test, {
+  env: {
+    es6: true
+  },
+  parserOptions: {
+    sourceType: 'module'
+  }
+});
+
+const errors = name => [{
+  ruleId: 'no-for-each',
+  message: 'Forbidden use of `_.' + name + '`'
+}];
+
+ruleTester.run('no-for-each', rule, {
+  valid: [
+    `import {toString} from './helpers'; toString();`
+  ],
+  invalid: [
+    {
+      code: code(`_.forEach(fn, array);`),
+      errors: errors('forEach')
+    }
+  ]
+});

--- a/test/preferred-alias.js
+++ b/test/preferred-alias.js
@@ -28,6 +28,7 @@ ruleTester.run('preferred-alias', rule, {
     code('_.get(a, b);'),
     code('_.getOr(a, b);'),
     code('_.foo(a, b);'),
+    code('_.toString({});'),
     code('foo(a, b);'),
     code('foo(a, b);', ['foo']),
     {

--- a/test/preferred-alias.js
+++ b/test/preferred-alias.js
@@ -28,7 +28,6 @@ ruleTester.run('preferred-alias', rule, {
     code('_.get(a, b);'),
     code('_.getOr(a, b);'),
     code('_.foo(a, b);'),
-    code('_.toString({});'),
     code('foo(a, b);'),
     code('foo(a, b);', ['foo']),
     {


### PR DESCRIPTION
This new test case will fail if `const imports = {};` is used and passes with `const imports = Object.create(null);`
in https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/rules/core/enhance.js