### PR TITLE
[fix] Ignore object prototype methods

### DIFF
--- a/rules/core/enhance.js
+++ b/rules/core/enhance.js
@@ -21,7 +21,7 @@ function strippedModuleName(strippedName, name) {
 }
 
 module.exports = function () {
-  const imports = {};
+  const imports = Object.create(null);
 
   // `ImportDeclaration` and `VariableDeclarator` will find Lodash imports and require()
   // and fill `imports` with what is found

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -13,5 +13,9 @@ module.exports = {
       return `import {${header.join(', ')}} from 'lodash/fp';${content}`;
     }
     return importHeader(header || '_') + content;
+  },
+
+  toString(value) {
+    return `${value}`;
   }
 };

--- a/test/object-prototype-methods.js
+++ b/test/object-prototype-methods.js
@@ -1,0 +1,30 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/no-for-each';
+import {code} from './helpers';
+
+const ruleTester = avaRuleTester(test, {
+  env: {
+    es6: true
+  },
+  parserOptions: {
+    sourceType: 'module'
+  }
+});
+
+const errors = name => [{
+  ruleId: 'no-for-each',
+  message: 'Forbidden use of `_.' + name + '`'
+}];
+
+ruleTester.run('no-for-each', rule, {
+  valid: [
+    `import {toString} from './helpers'; toString();`
+  ],
+  invalid: [
+    {
+      code: code(`_.forEach(fn, array);`),
+      errors: errors('forEach')
+    }
+  ]
+});


### PR DESCRIPTION
* [x] Fixing `const imports = Object.create(null)` in [enhance.js](https://github.com/jfmengels/eslint-plugin-lodash-fp/blob/master/rules/core/enhance.js#L24) to ignore object prototype methods
* [x] New test case that will fail with `const imports = {};` is used and passes with `const imports = Object.create(null);`

This PR replaces #89
Closes #51 
Closes #53 
Closes #60 
Closes #61 
Closes #67 
Closes #75
